### PR TITLE
Fix crash when using requires/optional with Entity

### DIFF
--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -358,8 +358,9 @@ module Grape
         # type casted values
         coerce_type validations, attrs, doc, opts
 
+        excluded_keywords = %i[as required param_type is_array format]
         validations.each do |type, options|
-          next if type == :as
+          next if excluded_keywords.include?(type)
 
           validate(type, options, attrs, doc, opts)
         end


### PR DESCRIPTION
when that entity specifies keywords that grape interprets as custom validators, ie: is_array, param_type, etc.

This PR changes it so that it skips looking for a custom validator for those special documentation keywords.

This allows you to do something like:

```rb
desc 'Create some entity',
     entity: SomeEntity,
     params: SomeEntity.documentation
params do
  requires :none,
           except: %i[field1 field2],
           using:
             SomeEntity.documentation
end
post do
 ...
end
```

and SomeEntity can specify documentation like:

```rb
      class SomeEntity < Grape::Entity
        expose :id, documentation: { type: Integer, format: 'int64', desc: 'ID' }
        expose :name, documentation: { type: String, desc: 'Name', require: true, param_type: 'body' }
        expose :array_field,
               documentation: {
                 type: String,
                 desc: 'Array Field',
                 require: true,
                 param_type: 'bold'
               }
      end
```

and it won't crash on startup and give you correct documentation and param validation to boot.

Open questions:
1. Is this an exhaustive list of keywords?
2. Is there a better way to maintain/get the list of keywords?
3. Is there a better approach altogeher?