### PR TITLE
Allow specifying a handler for grape_exceptions

### DIFF
--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -116,6 +116,7 @@ module Grape
           elsif args.include?(:grape_exceptions)
             namespace_inheritable(:rescue_all, true)
             namespace_inheritable(:rescue_grape_exceptions, true)
+            namespace_inheritable :grape_exceptions_rescue_handler, handler
           else
             handler_type =
               case options[:rescue_subclasses]

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -292,7 +292,8 @@ module Grape
                 rescue_options: namespace_stackable_with_hash(:rescue_options) || {},
                 rescue_handlers: namespace_reverse_stackable_with_hash(:rescue_handlers) || {},
                 base_only_rescue_handlers: namespace_stackable_with_hash(:base_only_rescue_handlers) || {},
-                all_rescue_handler: namespace_inheritable(:all_rescue_handler)
+                all_rescue_handler: namespace_inheritable(:all_rescue_handler),
+                grape_exceptions_rescue_handler: namespace_inheritable(:grape_exceptions_rescue_handler)
 
       stack.concat namespace_stackable(:middleware)
 

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -109,7 +109,7 @@ module Grape
         return :error_response if klass == Grape::Exceptions::InvalidVersionHeader
         return unless options[:rescue_grape_exceptions] || !options[:rescue_all]
 
-        :error_response
+        options[:grape_exceptions_rescue_handler] || :default_rescue_handler
       end
 
       def rescue_handler_for_any_class(klass)

--- a/spec/grape/dsl/request_response_spec.rb
+++ b/spec/grape/dsl/request_response_spec.rb
@@ -148,14 +148,34 @@ module Grape
           it 'sets rescue all to true' do
             expect(subject).to receive(:namespace_inheritable).with(:rescue_all, true)
             expect(subject).to receive(:namespace_inheritable).with(:rescue_grape_exceptions, true)
+            expect(subject).to receive(:namespace_inheritable).with(:grape_exceptions_rescue_handler, nil)
             subject.rescue_from :grape_exceptions
           end
 
-          it 'sets rescue_grape_exceptions to true' do
+          it 'sets given proc as rescue handler' do
+            rescue_handler_proc = proc {}
             expect(subject).to receive(:namespace_inheritable).with(:rescue_all, true)
             expect(subject).to receive(:namespace_inheritable).with(:rescue_grape_exceptions, true)
-            subject.rescue_from :grape_exceptions
+            expect(subject).to receive(:namespace_inheritable).with(:grape_exceptions_rescue_handler, rescue_handler_proc)
+            subject.rescue_from :grape_exceptions, rescue_handler_proc
           end
+
+          it 'sets given block as rescue handler' do
+            rescue_handler_proc = proc {}
+            expect(subject).to receive(:namespace_inheritable).with(:rescue_all, true)
+            expect(subject).to receive(:namespace_inheritable).with(:rescue_grape_exceptions, true)
+            expect(subject).to receive(:namespace_inheritable).with(:grape_exceptions_rescue_handler, rescue_handler_proc)
+            subject.rescue_from :grape_exceptions, &rescue_handler_proc
+          end
+
+          it 'sets a rescue handler declared through :with option' do
+            with_block = -> { 'hello' }
+            expect(subject).to receive(:namespace_inheritable).with(:rescue_all, true)
+            expect(subject).to receive(:namespace_inheritable).with(:rescue_grape_exceptions, true)
+            expect(subject).to receive(:namespace_inheritable).with(:grape_exceptions_rescue_handler, an_instance_of(Proc))
+            subject.rescue_from :grape_exceptions, with: with_block
+          end
+
         end
 
         describe 'list of exceptions is passed' do


### PR DESCRIPTION
This allows you to customize the format of the error response for grape exceptions:

For example, you could do something like this:

```rb
rescue_from :grape_exceptions do |e|
  error!({ errors: [{ code: 'Error', message: e.message.squish }] }, e.status)
end
```

which would render like this:

```
{
  "errors": [
    {
      "code": "Error",
      "message": "Problem: message body does not match declared format Resolution: when specifying application/json as content-type, you must pass valid application/json in the request's 'body'"
    }
  ]
}
```